### PR TITLE
Enhance Spring Security for Basic Auth (Basic Auth Nonsense)

### DIFF
--- a/src/main/java/keysat/UserService.java
+++ b/src/main/java/keysat/UserService.java
@@ -67,4 +67,6 @@ public class UserService {
             return ResponseEntity.notFound().build();
         }
     }
+
+    
 }

--- a/src/main/java/keysat/config/Auth.java
+++ b/src/main/java/keysat/config/Auth.java
@@ -1,6 +1,8 @@
 package keysat.config;
 
 import keysat.repository.UserRepository;
+import keysat.service.CustomUserDetailsService;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.NoOpPasswordEncoder;
@@ -36,10 +38,10 @@ public class Auth {
     return new BCryptPasswordEncoder(); 
 }
 
-	@Bean
-	public UserDetailsService userDetailsService() {
-		return new JdbcUserDetailsManager(dataSource);
-	}
+@Bean
+public UserDetailsService userDetailsService() {
+    return new CustomUserDetailsService();
+}
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -56,7 +58,7 @@ public class Auth {
 				.and()
 				.authorizeHttpRequests((requests) -> requests
 				  		
-						.requestMatchers("/", "/home", "/login").permitAll()
+						.requestMatchers("/", "/home", "/login", "/auth/login").permitAll()
 						.requestMatchers("/secret").hasRole("USER")
 						.requestMatchers("/instructorsecret").hasRole("INSTRUCTOR")
 						.requestMatchers("/users/create").permitAll()

--- a/src/main/java/keysat/controller/AuthenticationController.java
+++ b/src/main/java/keysat/controller/AuthenticationController.java
@@ -1,14 +1,24 @@
 package keysat.controller;
 
 import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.sql.DataSource;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,22 +32,39 @@ import keysat.dto.LoginDTO;
 public class AuthenticationController {
 
     @Autowired
+    private UserDetailsService userDetailsService;
+
+    @Autowired
     private AuthenticationManager authenticationManager;
 
     @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody LoginDTO loginDTO, HttpServletRequest request) {
+    public ResponseEntity<?> login(@RequestBody LoginDTO loginDTO) {
         try {
+            // Authenticate the user
             Authentication authentication = authenticationManager.authenticate(
                     new UsernamePasswordAuthenticationToken(loginDTO.getUsername(), loginDTO.getPassword()));
             SecurityContextHolder.getContext().setAuthentication(authentication);
 
-            String authorizationValue = "Basic " + Base64.getEncoder().encodeToString(
+            // Fetch user details and roles
+            UserDetails userDetails = userDetailsService.loadUserByUsername(loginDTO.getUsername());
+            List<String> roles = userDetails.getAuthorities().stream()
+                    .map(GrantedAuthority::getAuthority)
+                    .collect(Collectors.toList());
+
+            // Prepare the authorization header value
+            String authHeaderValue = "Basic " + Base64.getEncoder().encodeToString(
                     (loginDTO.getUsername() + ":" + loginDTO.getPassword()).getBytes());
 
-            return ResponseEntity.ok()
-                    .header("Authorization", authorizationValue)
-                    .body("Logged in successfully.");
+            // Create a response body
+            Map<String, Object> responseBody = new HashMap<>();
+            responseBody.put("message", "Logged in successfully.");
+            responseBody.put("roles", roles);
+            responseBody.put("authorization", authHeaderValue); // Include the auth header value
+
+            // Return the response
+            return ResponseEntity.ok(responseBody);
         } catch (Exception e) {
+            e.printStackTrace(); // Log the stack trace for debugging
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Authentication failed.");
         }
     }

--- a/src/main/java/keysat/service/CustomUserDetailsService.java
+++ b/src/main/java/keysat/service/CustomUserDetailsService.java
@@ -1,0 +1,55 @@
+package keysat.service;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import keysat.entities.User;
+
+// MAGIC CODE BELOW PLS DO NOT TOUCH
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        // Fetch user details from the users table
+        User user = jdbcTemplate.queryForObject(
+            "SELECT username, password, enabled FROM users WHERE username=?",
+            new Object[]{username},
+            new BeanPropertyRowMapper<>(User.class)
+        );
+
+        if (user == null) {
+            throw new UsernameNotFoundException("User not found");
+        }
+
+        // Fetch authorities based on your custom logic
+        List<GrantedAuthority> authorities = jdbcTemplate.query(
+            "SELECT u.username, r.authority FROM users u " +
+            "JOIN user_roles ur ON u.user_id = ur.user_id " +
+            "JOIN role r ON ur.role_id = r.role_id WHERE u.username=?",
+            new Object[]{username},
+            (rs, rowNum) -> new SimpleGrantedAuthority(rs.getString("authority"))
+        );
+
+        return new org.springframework.security.core.userdetails.User(
+            user.getUsername(),
+            user.getPassword(),
+            user.isEnabled(),
+            true, true, true,
+            authorities
+        );
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,5 @@ spring.datasource.username=root
 spring.datasource.password=admin
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=update
+logging.level.org.springframework.security=DEBUG
+logging.level.org.springframework.jdbc.core=DEBUG


### PR DESCRIPTION
Introduced CustomUserDetailsService.java to handle user details retrieval, enabling role-based authentication and simplifying the security context's user principal handling since spring secure by default is not compatible with a basic auth authentication flow

Overhauled AuthenticationController.java to fix role retrieval in the login endpoint, ensuring the response now includes proper role-based authorization header responses for client-side use

Refactored Auth.java to use CustomUserDetailsService

Modified application.properties to do advanced debug logging because trying to make springsecure compatible with basic auth is a programming war crime and very complex.